### PR TITLE
Add equality test to comparators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,11 @@
             "src/PhpTrees/RopeFunctions.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "^9"
     },

--- a/src/PhpTrees/BinarySearchTree.php
+++ b/src/PhpTrees/BinarySearchTree.php
@@ -40,8 +40,8 @@ class BinarySearchTree implements \Iterator
 
     /**
      * sets the comparator for the values to be added/found with
-     * @param callable $comparator the comparing function to use, int the form function($a, $b), returning a bool
-     * @return bool weather the comparitor was set or not
+     * @param callable $comparator the comparing function to use, in the form function($a, $b), returning a bool OR one of -1, 0, 1
+     * @return bool whether the comparator was set or not
      */
     public function setComparator(callable $comparator) : bool
     {
@@ -114,13 +114,17 @@ class BinarySearchTree implements \Iterator
             return null;
         }
 
+        if ($this->comparator !== null) {
+            $result = $this->findComparator(node: $node, value: $value);
+            if ($result !== null) {
+                return $result;
+            }
+        }
+
         if ($node->getValue() == $value) {
             return $node;
         }
         else {
-            if ($this->comparator !== null) {
-                return $this->findComparator(node: $node, value: $value);
-            }
             if ($value > $node->getValue() && $node->getRightChild() !== null) {
                 return $this->find(node: $node->getRightChild(), value: $value);
             }
@@ -133,16 +137,21 @@ class BinarySearchTree implements \Iterator
 
     /**
      * finds a node based on the given comparator
+     * works with both bool or -1/0/1 style comparisons
+     *
      * @param mixed $value the value to look for
      * @return BstNode|null the node with the given value or null
      */
     private function findComparator(mixed $value, BstNode $node = null) : ?BstNode
     {
         $cmp = ($this->comparator)($node->getValue(), $value);
-        if ($cmp === true && $node->getRightChild() !== null) {
-            return $this->find(node: $node->getRightChild(), value: $value);
+        if ($cmp === 0) {
+            return $node;
         }
-        else if ($node->getLeftChild() !== null) {
+
+        if (($cmp === true || $cmp === 1) && $node->getRightChild() !== null) {
+            return $this->find(node: $node->getRightChild(), value: $value);
+        } elseif (($cmp === false || $cmp === -1) && $node->getLeftChild() !== null) {
             return $this->find(node: $node->getLeftChild(), value: $value);
         }
         return null;

--- a/src/PhpTrees/BstNode.php
+++ b/src/PhpTrees/BstNode.php
@@ -68,6 +68,8 @@ class BstNode
 
     /**
      * adds a new node based upon the comparator
+     * works with both bool or -1/0/1 style comparisons
+     *
      * @param mixed $value the value of the new node
      *
      * @note this should be renamed to something more descriptive
@@ -75,7 +77,7 @@ class BstNode
     private function addChildComparator(mixed $value) : void
     {
         $cmp = ($this->comparator)($this->value, $value);
-        if ($cmp === true) {
+        if ($cmp === true || $cmp === 1 || $cmp === 0) {
             if ($this->right === null) {
                 $this->right = new BstNode(parent: $this, value: $value);
                 $this->right->setComparator(comparator: $this->comparator);

--- a/tests/PhpTrees/BinaryHeapTest.php
+++ b/tests/PhpTrees/BinaryHeapTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpTrees;
+
 use PHPUnit\Framework\TestCase;
 use PhpTrees\BinaryHeap;
 

--- a/tests/PhpTrees/BinarySearchTreeTest.php
+++ b/tests/PhpTrees/BinarySearchTreeTest.php
@@ -1,8 +1,11 @@
 <?php
 
+namespace Tests\PhpTrees;
+
+use PhpTrees\BstNode;
 use PHPUnit\Framework\TestCase;
 use PhpTrees\BinarySearchTree;
-use PhpTrees\BstNode;
+use Tests\Product;
 
 final class BinarySearchTreeTest extends TestCase
 {
@@ -292,5 +295,32 @@ final class BinarySearchTreeTest extends TestCase
         $b->insertMultiple("12345", "12", "123", "123456", "1");
         $cmp = $b->setComparator(comparator: fn($val, $val2) : bool => strlen($val) <= strlen($val2));
         $this->assertFalse($cmp);
+    }
+
+    public function testComparatorUseForEquality()
+    {
+        $b = new BinarySearchTree(comparator: static function (Product $existing, Product $new): int {
+            // sorting and equaling by price only, disregarding the name, strcmp style
+            return $new->price <=> $existing->price ;
+        });
+        $b->insertMultiple(
+            new Product('ab', 2),
+            new Product('bb', 2),
+            new Product('dd', 4),
+            new Product('aa', 1),
+            new Product('cc', 3),
+            new Product('ac', 3),
+        );
+
+        $this->assertEquals(new Product('ab', 2), $b->getRoot()->getValue());
+        $this->assertEquals(new Product('aa', 1), $b->getRoot()->getLeftChild()->getValue());
+        $this->assertEquals(new Product('bb', 2), $b->getRoot()->getRightChild()->getValue());
+        $this->assertEquals(new Product('dd', 4), $b->getRoot()->getRightChild()->getRightChild()->getValue());
+
+        $this->assertSame(1, $b->getMinValue()->price);
+
+        $item = $b->find(value: new Product('random name', 3))->getValue();
+        $this->assertSame(3, $item->price);
+        $this->assertTrue(in_array($item->name, ['ac', 'cc'], true), $item->name);
     }
 }

--- a/tests/PhpTrees/BstNodeTest.php
+++ b/tests/PhpTrees/BstNodeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpTrees;
+
 use PHPUnit\Framework\TestCase;
 use PhpTrees\BstNode;
 

--- a/tests/PhpTrees/GenericNodeTest.php
+++ b/tests/PhpTrees/GenericNodeTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Tests\PhpTrees;
+
+use Exception;
 use PHPUnit\Framework\TestCase;
 use PhpTrees\GenericNode;
 

--- a/tests/PhpTrees/GenericTreeTest.php
+++ b/tests/PhpTrees/GenericTreeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpTrees;
+
 use PHPUnit\Framework\TestCase;
 use PhpTrees\GenericTree;
 

--- a/tests/PhpTrees/RopeFunctionsTest.php
+++ b/tests/PhpTrees/RopeFunctionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpTrees;
+
 use PHPUnit\Framework\TestCase;
 use PhpTrees\Rope;
 

--- a/tests/PhpTrees/RopeNodeTest.php
+++ b/tests/PhpTrees/RopeNodeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpTrees;
+
 use PHPUnit\Framework\TestCase;
 use PhpTrees\RopeNode;
 

--- a/tests/PhpTrees/RopeTest.php
+++ b/tests/PhpTrees/RopeTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Tests\PhpTrees;
+
+use Exception;
 use PHPUnit\Framework\TestCase;
 use PhpTrees\Rope;
 

--- a/tests/PhpTrees/StackTest.php
+++ b/tests/PhpTrees/StackTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpTrees;
+
 use PHPUnit\Framework\TestCase;
 use PhpTrees\Stack;
 

--- a/tests/Product.php
+++ b/tests/Product.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests;
+
+class Product
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $price,
+    ) {}
+}


### PR DESCRIPTION
Is this project alive? :)

Recently I tried implementing trees containing value objects and found out the bool comparators work poorly on those — the equality test usually goes with some numeric field, not the whole object (`==`), and the existing bool setup only allowed using the comparator for going left/right, and not testing the current node.

Thus the proposal to use -1/0/1 style comparators which would allow indicating equality, and open it up to use with VOs.

The current bool setup continues to work as well.

If accepted, there should be a change to https://github.com/CrimsonNynja/PHP-Trees/wiki/Binary-Search-Tree too I think.

This PR also has changes to autoloading setup in order to load the test VO class.